### PR TITLE
Fix Content-Length for utf8 HTTP body

### DIFF
--- a/lib/SauceLabs.js
+++ b/lib/SauceLabs.js
@@ -259,7 +259,7 @@ SauceLabs.prototype.send = function (message, callback) {
     headers: {
       'Accept':         'application/json',
       'Content-Type':   'application/json',
-      'Content-Length': body != null ? body.length : 0
+      'Content-Length': body != null ? Buffer.byteLength(body) : 0
     }
   });
   makeRequest(options, body, callback);


### PR DESCRIPTION
This fix a "malformed json response" error when sending a `updateJob` request with an unicode job name.
